### PR TITLE
Update dependencies in debian control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,5 +7,5 @@ Standards-Version: 3.6.2
 
 Package: openmediavault-loopmgmt
 Architecture: all
-Depends: openmediavault
+Depends: openmediavault, patch
 Description: Adds loop device management to OpenMediaVault


### PR DESCRIPTION
installation requires the 'patch' package and fails if it is not installed